### PR TITLE
Fix a test that fails when rest-client's version >= 2.0.0

### DIFF
--- a/test/test_openscap.rb
+++ b/test/test_openscap.rb
@@ -40,7 +40,7 @@ class TestOpenscap < MiniTest::Test
 
   def test_openscap_404
     stub_request(:get, %r{/openscap}).to_return(
-      body: 'Openscap option was not chosen',
+      body: '{"message": "Openscap option was not chosen"}',
       status: 404
     )
 


### PR DESCRIPTION
This test successes with rest-client 2.0.0-rc1 and fails with 2.0.0
The commit that caused this failure is a5b0998fdcdd366bf35aff29dc1299faaabb790e in rest-client[1]

without this fix in both versions the [json parsing of the response](https://github.com/moolitayer/image-inspector-client/blob/cff4ed26055d8cf5d2b07206e3320cffe1f17f4d/lib/image-inspector-client.rb#L56) fails;
with  2.0.0-rc  e.to_s gives
"404 Not Found: Openscap option was not chosen"
while with 2.0.0 e.to_s gives
"404 Not Found"

[1] note this commit can't be found in git hub for some reason, it's in git history though
