### PR TITLE
Expect plain text and not JSON in image-inspector responses

### DIFF
--- a/lib/image-inspector-client.rb
+++ b/lib/image-inspector-client.rb
@@ -56,7 +56,7 @@ module ImageInspectorClient
       rescue JSON::ParserError
         json_error_msg = {}
       end
-      err_message = json_error_msg['message'] || e.to_s
+      err_message = json_error_msg['message'] || e.response
       raise InspectorClientException.new(e.http_code, err_message)
     end
 

--- a/test/test_rest_client.rb
+++ b/test/test_rest_client.rb
@@ -1,0 +1,49 @@
+require 'common'
+
+# Tests for rest-client return values
+class TestRestClient < MiniTest::Test
+  def test_metadata_404_plaintext
+    stub_request(:get, %r{/metadata}).to_return(
+      body: 'No Metadata Given',
+      status: 404
+    )
+
+    e = assert_raises(ImageInspectorClient::InspectorClientException) do
+      ImageInspectorClient::Client.new('http://localhost:8080', 'v1')
+      .fetch_metadata
+    end
+
+    assert_equal(404, e.error_code)
+    assert_equal('No Metadata Given', e.message)
+  end
+
+  def test_metadata_404_json
+    stub_request(:get, %r{/metadata}).to_return(
+      body: '{"message": "No Metadata Given"}',
+      status: 404
+    )
+
+    e = assert_raises(ImageInspectorClient::InspectorClientException) do
+      ImageInspectorClient::Client.new('http://localhost:8080', 'v1')
+      .fetch_metadata
+    end
+
+    assert_equal(404, e.error_code)
+    assert_equal('No Metadata Given', e.message)
+  end
+
+  def test_metadata_404_empty_body
+    stub_request(:get, %r{/metadata}).to_return(
+      body: '',
+      status: 404
+    )
+
+    e = assert_raises(ImageInspectorClient::InspectorClientException) do
+      ImageInspectorClient::Client.new('http://localhost:8080', 'v1')
+      .fetch_metadata
+    end
+
+    assert_equal(404, e.error_code)
+    assert_equal('', e.message)
+  end
+end


### PR DESCRIPTION
This is in order to solve the problem that rest-client 2.0.0 introduced.
