### PR TITLE
InspectorClientException#to_s: don't crash without message

### DIFF
--- a/lib/image-inspector-client.rb
+++ b/lib/image-inspector-client.rb
@@ -94,7 +94,7 @@ module ImageInspectorClient
     end
 
     def to_s
-      'HTTP status code ' + @error_code.to_s + ', ' + @message
+      "HTTP status code #{@error_code}, #{@message}"
     end
   end
 end


### PR DESCRIPTION
I've encountered a case where the real problem got obscured because message was nil, so logging code couldn't print the InspectorClientException:

```
[----] E, [2017-02-08T12:51:02.495524 #16640:2acf59be3950] ERROR -- : MIQ(MiqPriorityWorker::Runner) ID [192] PID [16640] GUID [20d0dd24-edeb-11e6-a69b-024224169cc6] An error has occurred during work processing: no implicit conversion of nil into String
/home/bpaskinc/myenv/rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/image-inspector-client-1.0.3/lib/image-inspector-client.rb:97:in `+'
/home/bpaskinc/myenv/rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/image-inspector-client-1.0.3/lib/image-inspector-client.rb:97:in `to_s'
/home/bpaskinc/miq/app/models/miq_queue.rb:367:in `rescue in deliver'
```

Can't say yet how exactly it was nil, need this patch to find out :-)
Anyway, to_s should never crash.